### PR TITLE
Add more languages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <repository>
             <id>mathias-maven</id>
             <name>Mathias's Maven Repository</name>
-            <url>https://mvn.coolcraft.ovh/snapshots</url>
+            <url>https://mvn.coolcraft.ovh/releases</url>
         </repository>
         <repository>
             <id>sonatype</id>
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>gg.gyro</groupId>
             <artifactId>LocaleAPI</artifactId>
-            <version>SNAPSHOT</version>
+            <version>snapshot</version>
         </dependency>
         <dependency>
             <groupId>net.objecthunter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
+            <id>mathias-maven</id>
+            <name>Mathias's Maven Repository</name>
+            <url>https://mvn.coolcraft.ovh/snapshots</url>
+        </repository>
+        <repository>
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
@@ -79,6 +84,11 @@
             <artifactId>spigot-api</artifactId>
             <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>gg.gyro</groupId>
+            <artifactId>LocaleAPI</artifactId>
+            <version>SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>net.objecthunter</groupId>

--- a/src/main/java/me/jojjjo147/jLevels/JLevels.java
+++ b/src/main/java/me/jojjjo147/jLevels/JLevels.java
@@ -8,7 +8,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import org.bstats.bukkit.Metrics;
-import org.bukkit.plugin.java.JavaPlugin;
+import gg.gyro.localeAPI.Locales;
 
 public final class JLevels extends JavaPlugin {
 
@@ -18,6 +18,11 @@ public final class JLevels extends JavaPlugin {
     public void onEnable() {
 
         saveDefaultConfig();
+
+        Locales.saveDefaultConfig(this, "en_us.yml");
+        Locales.saveDefaultConfig(this, "fr_fr.yml");
+
+        Locales locales = new Locales(this, getConfig().getString("default_language"));
 
         xpmg = new XPManager(this);
 

--- a/src/main/java/me/jojjjo147/jLevels/JLevels.java
+++ b/src/main/java/me/jojjjo147/jLevels/JLevels.java
@@ -5,6 +5,7 @@ import me.jojjjo147.jLevels.commands.GiveBottleCommand;
 import me.jojjjo147.jLevels.commands.LevelCommand;
 import me.jojjjo147.jLevels.listeners.*;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import org.bstats.bukkit.Metrics;
@@ -13,16 +14,21 @@ import gg.gyro.localeAPI.Locales;
 public final class JLevels extends JavaPlugin {
 
     private static XPManager xpmg;
+    private static Locales locales;
 
     @Override
     public void onEnable() {
 
         saveDefaultConfig();
 
-        Locales.saveDefaultConfig(this, "en_us.yml");
-        Locales.saveDefaultConfig(this, "fr_fr.yml");
+        if (!getConfig().getBoolean("uniform_language")) {
+            Locales.saveDefaultConfig(this, getConfig().getString("default_language") + ".yml");
+        } else {
+            Locales.saveDefaultConfig(this, "en_us.yml");
+            Locales.saveDefaultConfig(this, "fr_fr.yml");
+        }
 
-        Locales locales = new Locales(this, getConfig().getString("default_language"));
+        locales = new Locales(this, getConfig().getString("default_language"));
 
         xpmg = new XPManager(this);
 
@@ -60,5 +66,11 @@ public final class JLevels extends JavaPlugin {
         return xpmg;
     }
 
-
+    public String getString(Player target, String key) {
+        if (getConfig().getBoolean("uniform_language")) {
+            return locales.get(key);
+        } else {
+            return locales.get(target.getLocale(), key);
+        }
+    }
 }

--- a/src/main/java/me/jojjjo147/jLevels/PlaceholderApiHook.java
+++ b/src/main/java/me/jojjjo147/jLevels/PlaceholderApiHook.java
@@ -2,11 +2,9 @@ package me.jojjjo147.jLevels;
 
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.NamespacedKey;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
-import org.checkerframework.checker.units.qual.N;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/me/jojjjo147/jLevels/XPManager.java
+++ b/src/main/java/me/jojjjo147/jLevels/XPManager.java
@@ -57,7 +57,7 @@ public class XPManager {
                     rewards = plugin.getConfig().getStringList("level-rewards." + level + ".text");
                 }
 
-                p.sendMessage(ChatColor.translateAlternateColorCodes('&', applyPlaceholders(level, rewards, locales.get(p.getLocale(), "message-levelup"))));
+                p.sendMessage(ChatColor.translateAlternateColorCodes('&', applyPlaceholders(level, rewards, plugin.getString(p, "message-levelup"))));
 
                 ConsoleCommandSender console = Bukkit.getServer().getConsoleSender();
 
@@ -82,7 +82,7 @@ public class XPManager {
     }
 
     public void sendActionbar(Player p, int amount, String reason) {
-        p.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', applyActionbarPlaceholders(amount, reason, locales.get(p.getLocale(), "actionbar-gained-xp")))));
+        p.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', applyActionbarPlaceholders(amount, reason, plugin.getString(p, "actionbar-gained-xp")))));
     }
 
     public String applyActionbarPlaceholders(int xp, String reason, String text) {

--- a/src/main/java/me/jojjjo147/jLevels/XPManager.java
+++ b/src/main/java/me/jojjjo147/jLevels/XPManager.java
@@ -1,5 +1,6 @@
 package me.jojjjo147.jLevels;
 
+import gg.gyro.localeAPI.Locales;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.objecthunter.exp4j.Expression;
@@ -19,6 +20,7 @@ import java.util.List;
 public class XPManager {
 
     private final JLevels plugin;
+    private final Locales locales = Locales.getInstance();
 
     public XPManager(JLevels plugin) {
         this.plugin = plugin;
@@ -55,7 +57,7 @@ public class XPManager {
                     rewards = plugin.getConfig().getStringList("level-rewards." + level + ".text");
                 }
 
-                p.sendMessage(ChatColor.translateAlternateColorCodes('&', applyPlaceholders(level, rewards, plugin.getConfig().getString("lang.message-levelup"))));
+                p.sendMessage(ChatColor.translateAlternateColorCodes('&', applyPlaceholders(level, rewards, locales.get(p.getLocale(), "message-levelup"))));
 
                 ConsoleCommandSender console = Bukkit.getServer().getConsoleSender();
 
@@ -80,7 +82,7 @@ public class XPManager {
     }
 
     public void sendActionbar(Player p, int amount, String reason) {
-        p.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', applyActionbarPlaceholders(amount, reason, plugin.getConfig().getString("lang.actionbar-gained-xp")))));
+        p.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', applyActionbarPlaceholders(amount, reason, locales.get(p.getLocale(), "actionbar-gained-xp")))));
     }
 
     public String applyActionbarPlaceholders(int xp, String reason, String text) {

--- a/src/main/java/me/jojjjo147/jLevels/commands/AddXPCommand.java
+++ b/src/main/java/me/jojjjo147/jLevels/commands/AddXPCommand.java
@@ -44,24 +44,24 @@ public class AddXPCommand implements CommandExecutor {
                             xpReason = xpReason.substring(0, xpReason.length() - 1);
 
                         } else {
-                            xpReason = locales.get(target.getLocale(), "xpreason-admin");
+                            xpReason = plugin.getString(target, "xpreason-admin");
 
                         }
 
                         xpmg.addXP(target, xpAmount, xpReason);
 
-                        commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "message-add-xp")));
+                        commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getString(p, "message-add-xp")));
 
                     } else {
-                        commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "message-invalid-player")));
+                        commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getString(p, "message-invalid-player")));
                     }
 
                 } catch (NumberFormatException e) {
-                    commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "message-xp-number")));
+                    commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getString(p, "message-xp-number")));
                 }
 
             } else {
-                commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "message-missing-arguments")));
+                commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getString(p, "message-missing-arguments")));
             }
         } else {
             commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get("command-not-player")));

--- a/src/main/java/me/jojjjo147/jLevels/commands/AddXPCommand.java
+++ b/src/main/java/me/jojjjo147/jLevels/commands/AddXPCommand.java
@@ -16,7 +16,7 @@ public class AddXPCommand implements CommandExecutor {
     private final XPManager xpmg;
     private final Locales locales = Locales.getInstance();
 
-    public AddXPCommand(JLevels plugin, XPManager xpmg, Locales locales) {
+    public AddXPCommand(JLevels plugin, XPManager xpmg) {
         this.plugin = plugin;
         this.xpmg = xpmg;
     }

--- a/src/main/java/me/jojjjo147/jLevels/commands/AddXPCommand.java
+++ b/src/main/java/me/jojjjo147/jLevels/commands/AddXPCommand.java
@@ -1,5 +1,6 @@
 package me.jojjjo147.jLevels.commands;
 
+import gg.gyro.localeAPI.Locales;
 import me.jojjjo147.jLevels.JLevels;
 import me.jojjjo147.jLevels.XPManager;
 import org.bukkit.Bukkit;
@@ -13,16 +14,15 @@ public class AddXPCommand implements CommandExecutor {
 
     private final JLevels plugin;
     private final XPManager xpmg;
+    private final Locales locales = Locales.getInstance();
 
-    public AddXPCommand(JLevels plugin, XPManager xpmg) {
+    public AddXPCommand(JLevels plugin, XPManager xpmg, Locales locales) {
         this.plugin = plugin;
         this.xpmg = xpmg;
-
     }
 
     @Override
     public boolean onCommand(CommandSender commandSender, Command command, String s, String[] args) {
-
         if (commandSender instanceof Player p) {
             if (args.length > 1) {
 
@@ -44,27 +44,27 @@ public class AddXPCommand implements CommandExecutor {
                             xpReason = xpReason.substring(0, xpReason.length() - 1);
 
                         } else {
-                            xpReason = plugin.getConfig().getString("lang.xpreason-admin");
+                            xpReason = locales.get(target.getLocale(), "xpreason-admin");
 
                         }
 
                         xpmg.addXP(target, xpAmount, xpReason);
 
-                        commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("lang.message-add-xp")));
+                        commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "message-add-xp")));
 
                     } else {
-                        commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("lang.message-invalid-player")));
+                        commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "message-invalid-player")));
                     }
 
                 } catch (NumberFormatException e) {
-                    commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("lang.message-xp-number")));
+                    commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "message-xp-number")));
                 }
 
             } else {
-                commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("lang.message-missing-arguments")));
+                commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "message-missing-arguments")));
             }
         } else {
-            commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("lang.command-not-player")));
+            commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get("command-not-player")));
         }
 
         return true;

--- a/src/main/java/me/jojjjo147/jLevels/commands/GiveBottleCommand.java
+++ b/src/main/java/me/jojjjo147/jLevels/commands/GiveBottleCommand.java
@@ -2,7 +2,6 @@ package me.jojjjo147.jLevels.commands;
 
 import gg.gyro.localeAPI.Locales;
 import me.jojjjo147.jLevels.JLevels;
-import me.jojjjo147.jLevels.XPManager;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;

--- a/src/main/java/me/jojjjo147/jLevels/commands/GiveBottleCommand.java
+++ b/src/main/java/me/jojjjo147/jLevels/commands/GiveBottleCommand.java
@@ -1,5 +1,6 @@
 package me.jojjjo147.jLevels.commands;
 
+import gg.gyro.localeAPI.Locales;
 import me.jojjjo147.jLevels.JLevels;
 import me.jojjjo147.jLevels.XPManager;
 import org.bukkit.ChatColor;
@@ -19,6 +20,7 @@ import java.util.Arrays;
 public class GiveBottleCommand implements CommandExecutor {
 
     private final JLevels plugin;
+    private final Locales locales = Locales.getInstance();
 
     public GiveBottleCommand(JLevels plugin) {
         this.plugin = plugin;
@@ -38,9 +40,9 @@ public class GiveBottleCommand implements CommandExecutor {
                 try {
                     data.set(new NamespacedKey(plugin, "jxp"), PersistentDataType.INTEGER, Integer.valueOf(args[0]));
 
-                    meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("lang.name-xpbottle").replace("%xp%", args[0])));
+                    meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "name-xpbottle").replace("%xp%", args[0])));
                     meta.setLore(Arrays.asList(
-                            ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("lang.lore-xpbottle").replace("%xp%", args[0]))
+                            ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "lore-xpbottle").replace("%xp%", args[0]))
                     ));
 
                     item.setItemMeta(meta);
@@ -48,18 +50,18 @@ public class GiveBottleCommand implements CommandExecutor {
 
                     p.getInventory().addItem(item);
 
-                    commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("lang.message-xpbottle-given")));
+                    commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "message-xpbottle-given")));
 
                 } catch (NumberFormatException e) {
-                    commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("lang.message-xp-number")));
+                    commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "message-xp-number")));
                 }
 
             } else {
-                commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("lang.message-missing-arguments")));
+                commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "message-missing-arguments")));
             }
 
         } else {
-            commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("lang.command-not-player")));
+            commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get("command-not-player")));
         }
 
         return true;

--- a/src/main/java/me/jojjjo147/jLevels/commands/GiveBottleCommand.java
+++ b/src/main/java/me/jojjjo147/jLevels/commands/GiveBottleCommand.java
@@ -39,9 +39,9 @@ public class GiveBottleCommand implements CommandExecutor {
                 try {
                     data.set(new NamespacedKey(plugin, "jxp"), PersistentDataType.INTEGER, Integer.valueOf(args[0]));
 
-                    meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "name-xpbottle").replace("%xp%", args[0])));
+                    meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', plugin.getString(p, "name-xpbottle").replace("%xp%", args[0])));
                     meta.setLore(Arrays.asList(
-                            ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "lore-xpbottle").replace("%xp%", args[0]))
+                            ChatColor.translateAlternateColorCodes('&', plugin.getString(p, "lore-xpbottle").replace("%xp%", args[0]))
                     ));
 
                     item.setItemMeta(meta);
@@ -49,14 +49,14 @@ public class GiveBottleCommand implements CommandExecutor {
 
                     p.getInventory().addItem(item);
 
-                    commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "message-xpbottle-given")));
+                    commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getString(p, "message-xpbottle-given")));
 
                 } catch (NumberFormatException e) {
-                    commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "message-xp-number")));
+                    commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getString(p, "message-xp-number")));
                 }
 
             } else {
-                commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get(p.getLocale(), "message-missing-arguments")));
+                commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getString(p, "message-missing-arguments")));
             }
 
         } else {

--- a/src/main/java/me/jojjjo147/jLevels/commands/LevelCommand.java
+++ b/src/main/java/me/jojjjo147/jLevels/commands/LevelCommand.java
@@ -28,7 +28,7 @@ public class LevelCommand implements CommandExecutor {
 
         if (commandSender instanceof Player p) {
 
-            String message = locales.get(p.getLocale(), "message-level");
+            String message = plugin.getString(p, "message-level");
             message = applyPlaceholders(p, message);
 
             commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', message));

--- a/src/main/java/me/jojjjo147/jLevels/commands/LevelCommand.java
+++ b/src/main/java/me/jojjjo147/jLevels/commands/LevelCommand.java
@@ -1,5 +1,6 @@
 package me.jojjjo147.jLevels.commands;
 
+import gg.gyro.localeAPI.Locales;
 import net.objecthunter.exp4j.Expression;
 import net.objecthunter.exp4j.ExpressionBuilder;
 
@@ -16,6 +17,7 @@ import org.bukkit.persistence.PersistentDataType;
 public class LevelCommand implements CommandExecutor {
 
     private final JLevels plugin;
+    private final Locales locales = Locales.getInstance();
 
     public LevelCommand(JLevels plugin) {
         this.plugin = plugin;
@@ -26,13 +28,13 @@ public class LevelCommand implements CommandExecutor {
 
         if (commandSender instanceof Player p) {
 
-            String message = plugin.getConfig().getString("lang.message-level");
+            String message = locales.get(p.getLocale(), "message-level");
             message = applyPlaceholders(p, message);
 
             commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', message));
 
         } else {
-            commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("lang.command-not-player")));
+            commandSender.sendMessage(ChatColor.translateAlternateColorCodes('&', locales.get("command-not-player")));
         }
 
         return true;

--- a/src/main/java/me/jojjjo147/jLevels/listeners/AchievementListener.java
+++ b/src/main/java/me/jojjjo147/jLevels/listeners/AchievementListener.java
@@ -27,7 +27,7 @@ public class AchievementListener implements Listener {
         if (!key.getKey().startsWith("recipes/")) {
 
             Player p = e.getPlayer();
-            xpmg.addXP(p, plugin.getConfig().getInt("rewards.achievement"), locales.get(p.getLocale(), "xpreason-achievement"));
+            xpmg.addXP(p, plugin.getConfig().getInt("rewards.achievement"), plugin.getString(p, "xpreason-achievement"));
 
         }
 

--- a/src/main/java/me/jojjjo147/jLevels/listeners/AchievementListener.java
+++ b/src/main/java/me/jojjjo147/jLevels/listeners/AchievementListener.java
@@ -1,5 +1,6 @@
 package me.jojjjo147.jLevels.listeners;
 
+import gg.gyro.localeAPI.Locales;
 import me.jojjjo147.jLevels.JLevels;
 import me.jojjjo147.jLevels.XPManager;
 import org.bukkit.NamespacedKey;
@@ -12,6 +13,7 @@ public class AchievementListener implements Listener {
 
     private final JLevels plugin;
     private final XPManager xpmg;
+    private final Locales locales = Locales.getInstance();
 
     public AchievementListener(JLevels plugin, XPManager xpmg) {
         this.plugin = plugin;
@@ -25,7 +27,7 @@ public class AchievementListener implements Listener {
         if (!key.getKey().startsWith("recipes/")) {
 
             Player p = e.getPlayer();
-            xpmg.addXP(p, plugin.getConfig().getInt("rewards.achievement"), plugin.getConfig().getString("lang.xpreason-achievement"));
+            xpmg.addXP(p, plugin.getConfig().getInt("rewards.achievement"), locales.get(p.getLocale(), "xpreason-achievement"));
 
         }
 

--- a/src/main/java/me/jojjjo147/jLevels/listeners/MobKillListener.java
+++ b/src/main/java/me/jojjjo147/jLevels/listeners/MobKillListener.java
@@ -1,5 +1,6 @@
 package me.jojjjo147.jLevels.listeners;
 
+import gg.gyro.localeAPI.Locales;
 import me.jojjjo147.jLevels.XPManager;
 import net.objecthunter.exp4j.Expression;
 import net.objecthunter.exp4j.ExpressionBuilder;
@@ -22,6 +23,7 @@ public class MobKillListener implements Listener {
 
     private final JLevels plugin;
     private final XPManager xpmg;
+    private final Locales locales = Locales.getInstance();
 
     public MobKillListener(JLevels plugin, XPManager xpmg) {
         this.plugin = plugin;
@@ -34,7 +36,7 @@ public class MobKillListener implements Listener {
         if (e.getEntity().getKiller() instanceof Player p && e.getEntity() instanceof Monster) {
 
             int xpAmount = plugin.getConfig().getInt("rewards.monster-kill");
-            xpmg.addXP(p, xpAmount, plugin.getConfig().getString("lang.xpreason-moster-killed"));
+            xpmg.addXP(p, xpAmount, locales.get(p.getLocale(), "xpreason-moster-killed"));
 
         }
 

--- a/src/main/java/me/jojjjo147/jLevels/listeners/MobKillListener.java
+++ b/src/main/java/me/jojjjo147/jLevels/listeners/MobKillListener.java
@@ -2,22 +2,13 @@ package me.jojjjo147.jLevels.listeners;
 
 import gg.gyro.localeAPI.Locales;
 import me.jojjjo147.jLevels.XPManager;
-import net.objecthunter.exp4j.Expression;
-import net.objecthunter.exp4j.ExpressionBuilder;
 
 import me.jojjjo147.jLevels.JLevels;
-import net.md_5.bungee.api.ChatMessageType;
-import net.md_5.bungee.api.chat.TextComponent;
-import org.bukkit.ChatColor;
-import org.bukkit.NamespacedKey;
-import org.bukkit.Sound;
 import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
-import org.bukkit.persistence.PersistentDataContainer;
-import org.bukkit.persistence.PersistentDataType;
 
 public class MobKillListener implements Listener {
 

--- a/src/main/java/me/jojjjo147/jLevels/listeners/MobKillListener.java
+++ b/src/main/java/me/jojjjo147/jLevels/listeners/MobKillListener.java
@@ -27,7 +27,7 @@ public class MobKillListener implements Listener {
         if (e.getEntity().getKiller() instanceof Player p && e.getEntity() instanceof Monster) {
 
             int xpAmount = plugin.getConfig().getInt("rewards.monster-kill");
-            xpmg.addXP(p, xpAmount, locales.get(p.getLocale(), "xpreason-moster-killed"));
+            xpmg.addXP(p, xpAmount, plugin.getString(p, "xpreason-moster-killed"));
 
         }
 

--- a/src/main/java/me/jojjjo147/jLevels/listeners/PlayerDeathListener.java
+++ b/src/main/java/me/jojjjo147/jLevels/listeners/PlayerDeathListener.java
@@ -25,7 +25,7 @@ public class PlayerDeathListener implements Listener {
         if (e.getEntity().getKiller() != null && e.getEntity().getKiller() instanceof Player killer) {
 
             int xpAmount = plugin.getConfig().getInt("rewards.player-kill");
-            xpmg.addXP(killer, xpAmount, locales.get(killer.getLocale(), "xpreason-player-killed"));
+            xpmg.addXP(killer, xpAmount, plugin.getString(killer, "xpreason-player-killed"));
 
         }
 

--- a/src/main/java/me/jojjjo147/jLevels/listeners/PlayerDeathListener.java
+++ b/src/main/java/me/jojjjo147/jLevels/listeners/PlayerDeathListener.java
@@ -1,5 +1,6 @@
 package me.jojjjo147.jLevels.listeners;
 
+import gg.gyro.localeAPI.Locales;
 import me.jojjjo147.jLevels.JLevels;
 import me.jojjjo147.jLevels.XPManager;
 import org.bukkit.entity.Player;
@@ -11,6 +12,7 @@ public class PlayerDeathListener implements Listener {
 
     private final JLevels plugin;
     private final XPManager xpmg;
+    private final Locales locales = Locales.getInstance();
 
     public PlayerDeathListener(JLevels plugin, XPManager xpmg) {
         this.plugin = plugin;
@@ -23,7 +25,7 @@ public class PlayerDeathListener implements Listener {
         if (e.getEntity().getKiller() != null && e.getEntity().getKiller() instanceof Player killer) {
 
             int xpAmount = plugin.getConfig().getInt("rewards.player-kill");
-            xpmg.addXP(killer, xpAmount, plugin.getConfig().getString("lang.xpreason-player-killed"));
+            xpmg.addXP(killer, xpAmount, locales.get(killer.getLocale(), "xpreason-player-killed"));
 
         }
 

--- a/src/main/java/me/jojjjo147/jLevels/listeners/XpBottleListener.java
+++ b/src/main/java/me/jojjjo147/jLevels/listeners/XpBottleListener.java
@@ -1,5 +1,6 @@
 package me.jojjjo147.jLevels.listeners;
 
+import gg.gyro.localeAPI.Locales;
 import me.jojjjo147.jLevels.JLevels;
 import me.jojjjo147.jLevels.XPManager;
 import org.bukkit.Material;
@@ -19,6 +20,7 @@ public class XpBottleListener implements Listener {
 
     private final JLevels plugin;
     private final XPManager xpmg;
+    private final Locales locales = Locales.getInstance();
 
     public XpBottleListener(JLevels plugin, XPManager xpmg) {
         this.plugin = plugin;
@@ -45,7 +47,7 @@ public class XpBottleListener implements Listener {
                     Player p = e.getPlayer();
                     item.setAmount(item.getAmount() - 1);
 
-                    xpmg.addXP(p, xpAmount, plugin.getConfig().getString("lang.xpreason-xpbottle"));
+                    xpmg.addXP(p, xpAmount, locales.get(p.getLocale(), "xpreason-xpbottle"));
                     p.playSound(p, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1, 1);
 
                 }

--- a/src/main/java/me/jojjjo147/jLevels/listeners/XpBottleListener.java
+++ b/src/main/java/me/jojjjo147/jLevels/listeners/XpBottleListener.java
@@ -46,7 +46,7 @@ public class XpBottleListener implements Listener {
                     Player p = e.getPlayer();
                     item.setAmount(item.getAmount() - 1);
 
-                    xpmg.addXP(p, xpAmount, locales.get(p.getLocale(), "xpreason-xpbottle"));
+                    xpmg.addXP(p, xpAmount, plugin.getString(p, "xpreason-xpbottle"));
                     p.playSound(p, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1, 1);
 
                 }

--- a/src/main/java/me/jojjjo147/jLevels/listeners/XpBottleListener.java
+++ b/src/main/java/me/jojjjo147/jLevels/listeners/XpBottleListener.java
@@ -14,7 +14,6 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
-import org.checkerframework.checker.units.qual.N;
 
 public class XpBottleListener implements Listener {
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,7 @@
 # ----------------- Settings -----------------
 
 default_language: en_us
+uniform_language: false
 xp-formula: "100 + x^1.8" # x is the current level of the player
 enable-placeholder-api: true
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,27 +1,6 @@
-# ----------------- Language -----------------
-
-lang:
-  command-not-player: "This command can only be executed by a player!"
-  message-level: "&7Your level is: &d%level%&7\nProgress to next level: &d%xp%/%required_xp%" # Available Placeholders: %player% %level% %xp% %required_xp%
-  message-levelup: "&4&l-----&r &kx&r &bLevel Up! &r&kx&r &4&l-----&r\n&7You are now Level &d%level%&7\nRewards:\n%rewards%\n&4&l-----&r &kx&r &bLevel Up! &r&kx&r &4&l-----&r" # Available Placeholders: %level% %rewards%
-  message-invalid-player: "&cInvalid player!"
-  message-xp-number: "&cPlease specify xp as a number!"
-  message-missing-arguments: "&cMissing arguments!"
-  message-add-xp: "&asuccessfully added xp to player"
-  message-xpbottle-given: "&aAddded XP Bottle(s) to your inventory"
-  actionbar-gained-xp: "&b&l+%xp%XP &7&o(%reason%)" # Available Placeholders: %xp% %reason%
-  xpreason-moster-killed: "Monster Killed"
-  xpreason-admin: "Given by Admin"
-  xpreason-achievement: "Achievement"
-  xpreason-xpbottle: "XP Bottle"
-  xpreason-player-killed: "Player Kill"
-  name-xpbottle: "&b%xp%XP" # Available Placeholders: %xp%
-  lore-xpbottle: "&7right click to get &b%xp%XP"  # Available Placeholders: %xp%
-
-# --------------------------------------------
-
 # ----------------- Settings -----------------
 
+default_language: en_us
 xp-formula: "100 + x^1.8" # x is the current level of the player
 enable-placeholder-api: true
 

--- a/src/main/resources/locales/en_us.yml
+++ b/src/main/resources/locales/en_us.yml
@@ -1,0 +1,16 @@
+command-not-player: "This command can only be executed by a player!"
+message-level: "&7Your level is: &d%level%&7\nProgress to next level: &d%xp%/%required_xp%" # Available Placeholders: %player% %level% %xp% %required_xp%
+message-levelup: "&4&l-----&r &kx&r &bLevel Up! &r&kx&r &4&l-----&r\n&7You are now Level &d%level%&7\nRewards:\n%rewards%\n&4&l-----&r &kx&r &bLevel Up! &r&kx&r &4&l-----&r" # Available Placeholders: %level% %rewards%
+message-invalid-player: "&cInvalid player!"
+message-xp-number: "&cPlease specify xp as a number!"
+message-missing-arguments: "&cMissing arguments!"
+message-add-xp: "&asuccessfully added xp to player"
+message-xpbottle-given: "&aAddded XP Bottle(s) to your inventory"
+actionbar-gained-xp: "&b&l+%xp%XP &7&o(%reason%)" # Available Placeholders: %xp% %reason%
+xpreason-moster-killed: "Monster Killed"
+xpreason-admin: "Given by Admin"
+xpreason-achievement: "Achievement"
+xpreason-xpbottle: "XP Bottle"
+xpreason-player-killed: "Player Kill"
+name-xpbottle: "&b%xp%XP" # Available Placeholders: %xp%
+lore-xpbottle: "&7right click to get &b%xp%XP"  # Available Placeholders: %xp%

--- a/src/main/resources/locales/fr_fr.yml
+++ b/src/main/resources/locales/fr_fr.yml
@@ -1,0 +1,16 @@
+command-not-player: "Cette commande peut seulement être utilisé par un joueur!"
+message-level: "&7Vous êtes niveau &d%level%&7\nProgression pour le niveau suivant: &d%xp%/%required_xp%" # Variables disponible: %player% %level% %xp% %required_xp%
+message-levelup: "&4&l-----&r &kx&r &bMontée de niveau! &r&kx&r &4&l-----&r\n&Vous êtes maintenant niveau &d%level%&7\nRécompenses:\n%rewards%\n&4&l-----&r &kx&r &bMontée de niveau! &r&kx&r &4&l-----&r" # Variables disponible: %level% %rewards%
+message-invalid-player: "&cJoueur invalide !"
+message-xp-number: "&cLes points d'expériences doivent être un nombre!"
+message-missing-arguments: "&cArguments manquants!"
+message-add-xp: "&aXP ajoutée au joueur"
+message-xpbottle-given: "&aDes fioles d'expérience ont été ajoutées à votre inventaire"
+actionbar-gained-xp: "&b&l+%xp%XP &7&o(%reason%)" # Variables disponible: %xp% %reason%
+xpreason-moster-killed: "Monstre tué"
+xpreason-admin: "Donnée par un admin"
+xpreason-achievement: "Succès"
+xpreason-xpbottle: "Fiole d'expérience"
+xpreason-player-killed: "Joueur tué"
+name-xpbottle: "&b%xp%XP" # Variables disponible: %xp%
+lore-xpbottle: "&7Clique-droit pour obtenir &b%xp%XP"  # Variables disponible: %xp%


### PR DESCRIPTION
I use [LocaleAPI](https://github.com/MathiasDPX/LocaleAPI),

<details>
<summary>Screenshots</summary>

Game in English
![game_in_english](https://github.com/user-attachments/assets/89e2f5d8-25d3-4e93-af2d-38ee5c5f6fd1)

Game in French
![game_in_french](https://github.com/user-attachments/assets/501f867b-b437-47a2-bde4-0acd11aa98f7)

Game in pirate (not supported)
![game_in_pirate](https://github.com/user-attachments/assets/fd9fab35-64d0-405d-9ceb-b43547ada521)
</details>

Servers owners can however translate plugins to their lang by adding a yml file in plugins/jLevels/locales